### PR TITLE
Bump rag api version to 0.3.0-3 and fix issue where initdb is not found in postgres run

### DIFF
--- a/rag_api/CHANGELOG.md
+++ b/rag_api/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
 
+## 0.3.0-3
+
+Fix issue where initdb is not found in postgres run
+
 ## 0.3.0-2
 
 Fix path in postgres runner

--- a/rag_api/config.yaml
+++ b/rag_api/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: RAG API
-version: "0.3.0-2"
+version: "0.3.0-3"
 slug: rag_api
 description: RAG API for LibreChat Add-on
 url: "https://github.com/BobbyQuantum/addon-librechat/tree/main/rag_api"

--- a/rag_api/rootfs/etc/services.d/postgres/run
+++ b/rag_api/rootfs/etc/services.d/postgres/run
@@ -12,7 +12,7 @@ chown -R postgres:postgres "$PGDATA"
 # Check if PostgreSQL data directory is empty
 if [ -z "$(ls -A "$PGDATA")" ]; then
     bashio::log.info "Initializing PostgreSQL database..."
-    su postgres -c "initdb -D $PGDATA"
+    su postgres -c "/usr/lib/postgresql/15/bin/initdb -D $PGDATA"
 
     # Enhanced PostgreSQL configuration
     {


### PR DESCRIPTION
Update `rag_api` version to 0.3.0-3 and fix `initdb` issue in PostgreSQL run script.

* **Version Update**
  - Update `rag_api/config.yaml` to set the version to "0.3.0-3".
  - Update `rag_api/CHANGELOG.md` to add an entry for version "0.3.0-3" mentioning the fix for the `initdb` issue.

* **PostgreSQL Initialization Fix**
  - Modify `rag_api/rootfs/etc/services.d/postgres/run` to ensure the `initdb` command is found and executed correctly by specifying the full path to the `initdb` binary.

