### PR TITLE
Fix PostgreSQL run command and bump version

### DIFF
--- a/rag_api/CHANGELOG.md
+++ b/rag_api/CHANGELOG.md
@@ -32,3 +32,7 @@ Add postgres pgvector db
 ## 0.2.0
 
 Initial version
+
+## 0.3.0-4
+
+Replace bashio::log.info with echo in postgres run script to fix unrecognized command issue.

--- a/rag_api/config.yaml
+++ b/rag_api/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: RAG API
-version: "0.3.0-3"
+version: "0.3.0-4"
 slug: rag_api
 description: RAG API for LibreChat Add-on
 url: "https://github.com/BobbyQuantum/addon-librechat/tree/main/rag_api"

--- a/rag_api/rootfs/etc/services.d/postgres/run
+++ b/rag_api/rootfs/etc/services.d/postgres/run
@@ -11,7 +11,7 @@ chown -R postgres:postgres "$PGDATA"
 
 # Check if PostgreSQL data directory is empty
 if [ -z "$(ls -A "$PGDATA")" ]; then
-    bashio::log.info "Initializing PostgreSQL database..."
+    echo "Initializing PostgreSQL database..."
     su postgres -c "/usr/lib/postgresql/15/bin/initdb -D $PGDATA"
 
     # Enhanced PostgreSQL configuration
@@ -50,7 +50,7 @@ if [ -z "$(ls -A "$PGDATA")" ]; then
 
     # Wait for PostgreSQL to start
     until su postgres -c "pg_isready" 2>/dev/null; do
-        bashio::log.info "Waiting for PostgreSQL to start..."
+        echo "Waiting for PostgreSQL to start..."
         sleep 1
     done
 
@@ -65,5 +65,5 @@ if [ -z "$(ls -A "$PGDATA")" ]; then
     su postgres -c "pg_ctl -D $PGDATA stop"
 fi
 
-bashio::log.info "Starting PostgreSQL with enhanced logging..."
-exec su postgres -c "postgres -D $PGDATA 2>&1 | bashio::log.info"
+echo "Starting PostgreSQL with enhanced logging..."
+exec su postgres -c "postgres -D $PGDATA"


### PR DESCRIPTION
Update PostgreSQL run script and bump version to 0.3.0-4.

* Replace `bashio::log.info` with `echo` in `rag_api/rootfs/etc/services.d/postgres/run` to fix the unrecognized command issue.
* Update the final start command in `rag_api/rootfs/etc/services.d/postgres/run` to use `exec` for PostgreSQL.
* Update the version in `rag_api/config.yaml` to 0.3.0-4.
* Add a new entry for version 0.3.0-4 in `rag_api/CHANGELOG.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bobbyquantum/addon-librechat/pull/19?shareId=723524e4-8efe-4cda-b76f-c3273cc5118a).