### PR TITLE
Add canary branch for publishing latest commit

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -8,9 +8,11 @@ on:
   push:
     branches:
       - main
+      - canary
   pull_request:
     branches:
       - main
+      - canary
 
 jobs:
   init:

--- a/librechat/Dockerfile
+++ b/librechat/Dockerfile
@@ -4,7 +4,6 @@ FROM $BUILD_FROM
 ARG BUILD_ARCH
 
 ARG MEILISEARCH_VERSION
-ARG LIBRECHAT_VERSION
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -17,7 +16,6 @@ RUN cd /opt/proxy && npm install http-proxy express http-proxy-middleware body-p
     mkdir /opt/librechat && \
     cd /opt/librechat && \
     git clone https://github.com/danny-avila/LibreChat.git . && \
-    git checkout tags/${LIBRECHAT_VERSION} && \
     npm ci && npm run frontend && \
     # fix permissions
     chmod +x /etc/services.d/mongodb/run \

--- a/librechat/config.yaml
+++ b/librechat/config.yaml
@@ -1,6 +1,5 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: LibreChat
-version: "0.7.6"
 slug: librechat
 description: Open-source AI chat platform integrating multiple models and services.
 url: "https://github.com/BobbyQuantum/addon-librechat/tree/main/librechat"
@@ -13,4 +12,4 @@ map:
   - addon_config:rw
 ports:
   3080/tcp: 3080
-image: "ghcr.io/bobbyquantum/{arch}-addon-librechat"
+image: "ghcr.io/bobbyquantum/{arch}-addon-librechat:canary"


### PR DESCRIPTION
Update the workflow and Dockerfile to support canary branch publishing with the latest commit from Librechat.

* **librechat/Dockerfile**
  - Remove the `LIBRECHAT_VERSION` argument.
  - Update the `git clone` command to clone the latest commit from the `main` branch.
  - Remove the `git checkout tags/${LIBRECHAT_VERSION}` command.

* **.github/workflows/builder.yaml**
  - Add the `canary` branch to the `push` and `pull_request` triggers.

* **librechat/config.yaml**
  - Remove the `version` field.
  - Update the `image` field to use the latest commit from the `canary` branch.

